### PR TITLE
通过将 wget 改为 curl 解决多出口绑定问题

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ define Package/$(PKG_NAME)
 	SUBMENU:=3. Applications
 	TITLE:=LuCI Support for XLNetAcc
 	PKGARCH:=all
-	DEPENDS:=+jshn +wget +openssl-util
+	DEPENDS:=+jshn +curl +openssl-util
 endef
 
 define Package/$(PKG_NAME)/description

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-xlnetacc
-PKG_VERSION:=1.0.5
+PKG_VERSION:=1.1.0
 PKG_RELEASE:=1
 
 PKG_LICENSE:=GPLv2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # luci-app-xlnetacc
 适用于 OpenWRT/LEDE 纯Shell实现的迅雷快鸟客户端
 
-依赖: wget openssl-util
+依赖: curl openssl-util
 
 
 更新到支持快鸟新协议 300


### PR DESCRIPTION
由于 wget 的 bind-address 功能在存在多个出口时不能正确选择出口接口：
```
root@OpenWRT:~# wget "ifconfig.me" -nv -O - --bind-address=100.67.55.91
58.32.10.22024-07-01 02:17:55 URL:http://ifconfig.me/ [10/10] -> "-" [1]
root@OpenWRT:~# wget "ifconfig.me" -nv -O - --bind-address=58.32.10.2
58.32.10.22024-07-01 02:20:17 URL:http://ifconfig.me/ [10/10] -> "-" [1]
```
所以将其改为 curl 来规避接口绑定问题，同时 curl 的体积更小，而且更多三方组件会依赖它
```
curl | 8.4.0-1 | ~61.38 KiB
wget-nossl | 1.21.4-1 | 190.46 KiB
wget-ssl | 1.21.4-1 | 212.41 KiB
```